### PR TITLE
fix index out of range when none of the ratios of holdings >= threhold

### DIFF
--- a/xalpha/info.py
+++ b/xalpha/info.py
@@ -1050,7 +1050,9 @@ class fundinfo(basicinfo):
         """
         d = self.get_industry_holdings()
         l = sorted([(k, v) for k, v in d.items()], key=lambda s: -s[1])
-        s0 = l[0][1]
+        s0 = 0
+        if l and l[0] and l[0][1]:
+            s0 = l[0][1]
         s1 = sum([l[i][1] for i in range(1, len(l))])
         if s0 > threhold * s1:
             return "行业基金： " + l[0][0]


### PR DESCRIPTION
以下是output，当所有的holdings的ratio都小于threhold,会导致index out of range
```
Python 3.7.3 (default, Mar  6 2020, 22:34:30) 
[Clang 11.0.3 (clang-1103.0.32.29)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import xalpha as xa
>>> nfyy = xa.fundinfo("007153")
>>> nfyy.which_industry()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/xxxx/Library/Python/3.7/lib/python/site-packages/xalpha-0.10.2-py3.7.egg/xalpha/info.py", line 1053, in which_industry
    s0 = l[0][1]
IndexError: list index out of range

```