### PR TITLE
可转债到期赎回价存在上标时需要从上标里爬取含息赎回价

### DIFF
--- a/tests/test_toolbox.py
+++ b/tests/test_toolbox.py
@@ -69,3 +69,7 @@ def test_cbcaculator():
     c = xa.CBCalculator("SH113577")
     d = c.analyse()
     assert d["name"] == "春秋转债"
+    # obtain correct redeem_price from superscipt
+    c = xa.CBCalculator("SH113604")
+    d = c.analyse()
+    assert d["name"] == "多伦转债"

--- a/xalpha/toolbox.py
+++ b/xalpha/toolbox.py
@@ -768,7 +768,13 @@ class CBCalculator:
             float(re.search(r"[\D]*([\d]*.[\d]*)[\s]*\%", s).group(1))
             for s in re.split("、|，", b.select("td[id=cpn_desc]")[0].string)
         ]
-        self.rlist.append(float(b.select("td[id=redeem_price]")[0].string))
+        td_redeem_price = b.select("td[id=redeem_price]")[0];
+        if td_redeem_price.sup:
+            redeem_price = float(re.match(r"\S+，合计到期赎回价(\d\d\d\.\d\d)元",td_redeem_price.sup['title']).group(1))
+            logger.warning("{}: redeem_price {} obtained from superscript".format(code, redeem_price))
+        else:
+            redeem_price = float(td_redeem_price.string)
+        self.rlist.append(redeem_price)
         self.rlist[-1] -= self.rlist[-2]  # 最后一年不含息返多少
         td_scode = b.select("td[class=jisilu_nav]")[0].contents[1]
         if td_scode.sup: td_scode = td_scode.contents[2]

--- a/xalpha/toolbox.py
+++ b/xalpha/toolbox.py
@@ -771,15 +771,13 @@ class CBCalculator:
         td_redeem_price = b.select("td[id=redeem_price]")[0];
         if td_redeem_price.sup:
             redeem_price = float(re.match(r"\S+，合计到期赎回价(\d\d\d\.\d\d)元",td_redeem_price.sup['title']).group(1))
-            logger.warning("{}: redeem_price {} obtained from superscript".format(code, redeem_price))
+            logger.info("{}: redeem_price {} obtained from superscript".format(code, redeem_price))
         else:
             redeem_price = float(td_redeem_price.string)
         self.rlist.append(redeem_price)
         self.rlist[-1] -= self.rlist[-2]  # 最后一年不含息返多少
-        td_scode = b.select("td[class=jisilu_nav]")[0].contents[1]
-        if td_scode.sup: td_scode = td_scode.contents[2]
         self.scode = (
-            td_scode.string.split("-")[1].strip()
+            b.select("td[class=jisilu_nav]")[0].contents[1].text.split("-")[1].strip()
         )
         self.scode = ttjjcode(self.scode)  # 标准化股票代码
         if not zgj:

--- a/xalpha/toolbox.py
+++ b/xalpha/toolbox.py
@@ -770,8 +770,10 @@ class CBCalculator:
         ]
         self.rlist.append(float(b.select("td[id=redeem_price]")[0].string))
         self.rlist[-1] -= self.rlist[-2]  # 最后一年不含息返多少
+        td_scode = b.select("td[class=jisilu_nav]")[0].contents[1]
+        if td_scode.sup: td_scode = td_scode.contents[2]
         self.scode = (
-            b.select("td[class=jisilu_nav]")[0].contents[1].text.split("-")[1].strip()
+            td_scode.string.split("-")[1].strip()
         )
         self.scode = ttjjcode(self.scode)  # 标准化股票代码
         if not zgj:


### PR DESCRIPTION
集思录显示的可转债到期赎回价有时不包含最后一期的利息，要从上标里爬取总的到期赎回价。