### PR TITLE
set start date of cashobj when backtest

### DIFF
--- a/xalpha/backtest.py
+++ b/xalpha/backtest.py
@@ -5,7 +5,7 @@ modules for dynamical backtesting framework
 
 import pandas as pd
 
-from xalpha.info import fundinfo, mfundinfo
+from xalpha.info import fundinfo, mfundinfo, cashinfo
 from xalpha.trade import trade
 from xalpha.multiple import mul, mulfix
 from xalpha.cons import yesterdayobj, avail_dates
@@ -92,7 +92,7 @@ class BTE:
         if self.trades:
             if totmoney is None:
                 totmoney = self.totmoney
-            return mulfix(*[v for _, v in self.trades.items()], totmoney=totmoney)
+            return mulfix(*[v for _, v in self.trades.items()], totmoney=totmoney, cashobj=cashinfo(start=self.start))
         else:
             return
 


### PR DESCRIPTION
在回测时，如果获取mulfix，目前是使用默认的cashobj，起始时间为2012-01-01。修改为回测起始时间，避免在获取mulfix时出错