### PR TITLE
possible pyecharts compatibility sulotion for all python versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,8 @@ setuptools.setup(
         "scipy",
         "matplotlib",
         "requests",
-        "pyecharts==1.7.1",  # broken api between 0.x and 1.x
+        "pyecharts==1.7.1;python_version<='3.9'",  # broken api between 0.x and 1.x
+        "pyecharts==1.9.1;python_version>'3.9'",
         "beautifulsoup4>=4.9.0",
         "sqlalchemy<2.0",
         "pysocks",  # sock5 proxy support

--- a/xalpha/indicator.py
+++ b/xalpha/indicator.py
@@ -633,8 +633,8 @@ def plot_kline(
         .add_js_funcs("var barData = {}".format(list(df["close"] - df["open"])))
         .add_xaxis(xaxis_data=list(df["date"]))
         .add_yaxis(
-            series_name="",
-            yaxis_data=vl,
+            "",
+            vl,
             label_opts=opts.LabelOpts(is_show=False),
             itemstyle_opts=opts.ItemStyleOpts(
                 color=JsCode(

--- a/xalpha/trade.py
+++ b/xalpha/trade.py
@@ -177,8 +177,8 @@ def vtradevolume(cftable, freq="D", rendered=True):
     datedata = list(datedata)
     bar.add_xaxis(xaxis_data=datedata)
     # buydata should before selldata, since emptylist in the first line would make the output fig empty: may be bug in pyecharts
-    bar.add_yaxis(series_name="买入", yaxis_data=buydata)
-    bar.add_yaxis(series_name="卖出", yaxis_data=selldata)
+    bar.add_yaxis("买入", buydata)
+    bar.add_yaxis("卖出", selldata)
     bar.set_global_opts(
         tooltip_opts=opts.TooltipOpts(
             is_show=True,


### PR DESCRIPTION
Force install pyecharts 1.9.1 in python 3.11.8 venv, the module worked fine as code below:
```python
#!/usr/bin/env python3

import xalpha

def main():
    info=xalpha.fundinfo("000692")
    print(info)
    print(info.info())
    print(info.price[info.price['date']<='2015-01-01'])
    info.v_netvalue()

if __name__ == "__main__":
    main()
```

This is a possible solution for issue #173 