### PR TITLE
修复导入包numpy报错问题

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setuptools.setup(
         "lxml",
         "pandas<2.0",
         "xlrd>=1.0.0",  #  read excel support
-        "numpy",
+        "numpy==1.26.4",
         "scipy",
         "matplotlib",
         "requests",


### PR DESCRIPTION
numpy.dtype size changed, may indicate binary incompatibility. Expected 96 from C header, got 88 from PyObject 
参考连接
https://stackoverflow.com/questions/78634235/numpy-dtype-size-changed-may-indicate-binary-incompatibility-expected-96-from