### PR TITLE
⚡ Optimize O(N^2) aggregation in _mergecftb

### DIFF
--- a/xalpha/multiple.py
+++ b/xalpha/multiple.py
@@ -215,22 +215,14 @@ class mul:
         """
         merge the different cftable for different funds into one table
         """
-        dtlist = []
-        for fund in self.fundtradeobj:
-            dtlist2 = []
-            for _, row in fund.cftable.iterrows():
-                dtlist2.append((row["date"], row["cash"]))
-            dtlist.extend(dtlist2)
+        if not self.fundtradeobj:
+            return pd.DataFrame([], columns=["date", "cash"])
 
-        nndtlist = set([item[0] for item in dtlist])
-        nndtlist = sorted(list(nndtlist), key=lambda x: x)
-        reslist = []
-        for date in nndtlist:
-            reslist.append(sum([item[1] for item in dtlist if item[0] == date]))
-        df = pd.DataFrame(data={"date": nndtlist, "cash": reslist})
+        df = pd.concat([fund.cftable for fund in self.fundtradeobj], ignore_index=True)
+        df = df.groupby("date")["cash"].sum().reset_index()
         df["date"] = pd.to_datetime(df["date"])
         df = df[df["cash"] != 0]
-        df = df.reset_index(drop=True)
+        df = df.sort_values(by="date").reset_index(drop=True)
         return df
 
     def xirrrate(self, date=yesterdayobj(), startdate=None, guess=0.01):


### PR DESCRIPTION
### 💡 What: The optimization implemented
Optimized the `_mergecftb` method in `xalpha/multiple.py` by replacing a manual, row-by-row aggregation process with vectorized Pandas operations.

### 🎯 Why: The performance problem it solves
The original implementation used an $O(N^2)$ approach where it first iterated over all transaction rows from all funds using `iterrows()` to build a list, and then for every unique date, it re-filtered that entire list to calculate the sum. This led to severe performance degradation as the number of funds or the length of the transaction history increased.

### 📊 Measured Improvement
Due to the environment lacking `pandas` and network access, direct benchmarking was not possible. However, the theoretical complexity has been reduced from $O(N \times M)$ (where $N$ is total transactions and $M$ is unique dates) to $O(N \log N)$ (primarily due to the grouping and sorting operations). In practice, using `pd.concat` and `groupby` utilizes optimized C-level implementations, which are orders of magnitude faster than Python-level loops and list comprehensions for this type of data manipulation.

Verified the change via `python3 -m py_compile` to ensure no syntax errors were introduced and performed a manual code review to ensure the logic remains functionally identical.

---
*PR created automatically by Jules for task [167193237784393486](https://jules.google.com/task/167193237784393486) started by @refraction-ray*