### PR TITLE
修复天天基金 F10DataApi 下线导致的增量更新失败

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- 修复天天基金 `f10/F10DataApi.aspx` 页面下线导致 `fundinfo` 和 `mfundinfo` 增量更新失败的问题，改用 `api.fund.eastmoney.com/f10/lsjz` 接口
+
 ## v0.12.4 - 2026.07.07
 
 - 移除 numpy 版本上限以兼容 Python 3.12 下的现代科学计算环境

--- a/xalpha/info.py
+++ b/xalpha/info.py
@@ -85,6 +85,39 @@ def _nfloat(string):
     return result
 
 
+def _lsjz_url(code, page=1, per=1):
+    """
+    历史净值 API 的 url，替代已下线的 f10/F10DataApi.aspx 页面
+
+    :param code: string, 六位基金代码
+    :param page: int, 页码
+    :param per: int, 每页条数，服务端上限为 20
+    :returns: string
+    """
+    return (
+        "https://api.fund.eastmoney.com/f10/lsjz?fundCode="
+        + code
+        + "&pageIndex="
+        + str(page)
+        + "&pageSize="
+        + str(per)
+    )
+
+
+def _lsjz_rows(url):
+    """
+    抓取历史净值 API 并返回净值列表
+
+    每行为 dict，其中 FSRQ 为净值日期，DWJZ 为单位净值（货币基金为每万份收益），
+    LJJZ 为累计净值（货币基金为七日年化），FHSP 为分红送配
+
+    :param url: string, :func:`_lsjz_url` 生成的 url
+    :returns: list of dict
+    """
+    r = rget_json(url, headers={"Referer": "https://fundf10.eastmoney.com/"})
+    return r["Data"]["LSJZList"]
+
+
 class FundReport:
     """
     提供查看各种基金报告的接口
@@ -989,41 +1022,20 @@ class fundinfo(basicinfo):
             diffdays == 0
         ):  ## for some QDII, this value is 1, anyways, trying update is compatible (d+2 update)
             return None
-        self._updateurl = (
-            "http://fund.eastmoney.com/f10/F10DataApi.aspx?type=lsjz&code="
-            + self.code
-            + "&page=1&per=1"
-        )
-        con = rget(self._updateurl)
-        soup = BeautifulSoup(con.text, "lxml")
-        items = soup.findAll("td")
-        if dt.datetime.strptime(str(items[0].string), "%Y-%m-%d") == today_obj():
+        self._updateurl = _lsjz_url(self.code, page=1, per=1)
+        items = _lsjz_rows(self._updateurl)
+        if dt.datetime.strptime(items[0]["FSRQ"], "%Y-%m-%d") == today_obj():
             diffdays += 1
         if diffdays <= 10:
-            self._updateurl = (
-                "http://fund.eastmoney.com/f10/F10DataApi.aspx?type=lsjz&code="
-                + self.code
-                + "&page=1&per="
-                + str(diffdays)
-            )
-            con = rget(self._updateurl)
-            soup = BeautifulSoup(con.text, "lxml")
-            items = soup.findAll("td")
+            self._updateurl = _lsjz_url(self.code, page=1, per=diffdays)
+            items = _lsjz_rows(self._updateurl)
         elif (
             diffdays > 10
         ):  ## there is a 20 item per page limit in the API, so to be safe, we query each page by 10 items only
             items = []
             for pg in range(1, int(diffdays / 10) + 2):
-                self._updateurl = (
-                    "http://fund.eastmoney.com/f10/F10DataApi.aspx?type=lsjz&code="
-                    + self.code
-                    + "&page="
-                    + str(pg)
-                    + "&per=10"
-                )
-                con = rget(self._updateurl)
-                soup = BeautifulSoup(con.text, "lxml")
-                items.extend(soup.findAll("td"))
+                self._updateurl = _lsjz_url(self.code, page=pg, per=10)
+                items.extend(_lsjz_rows(self._updateurl))
         else:
             raise TradeBehaviorError(
                 "Weird incremental update: the saved copy has future records"
@@ -1033,13 +1045,13 @@ class fundinfo(basicinfo):
         netvalue = []
         totvalue = []
         comment = []
-        for i in range(int(len(items) / 7)):
-            ts = pd.Timestamp(str(items[7 * i].string))
+        for item in items:
+            ts = pd.Timestamp(item["FSRQ"])
             if (ts - lastdate).days > 0:
                 date.append(ts)
-                netvalue.append(_float(items[7 * i + 1].string))
-                totvalue.append(_float(items[7 * i + 2].string))
-                comment.append(_nfloat(items[7 * i + 6].string))
+                netvalue.append(_float(item["DWJZ"]))
+                totvalue.append(_float(item["LJJZ"]))
+                comment.append(_nfloat(item["FHSP"]))
             else:
                 break
         df = pd.DataFrame(
@@ -1585,42 +1597,21 @@ class mfundinfo(basicinfo):
         diffdays = (yesterdayobj() - lastdate).days
         if diffdays == 0:
             return None
-        self._updateurl = (
-            "http://fund.eastmoney.com/f10/F10DataApi.aspx?type=lsjz&code="
-            + self.code
-            + "&page=1&per=1"
-        )
-        con = rget(self._updateurl)
-        soup = BeautifulSoup(con.text, "lxml")
-        items = soup.findAll("td")
-        if dt.datetime.strptime(str(items[0].string), "%Y-%m-%d") == today_obj():
+        self._updateurl = _lsjz_url(self.code, page=1, per=1)
+        items = _lsjz_rows(self._updateurl)
+        if dt.datetime.strptime(items[0]["FSRQ"], "%Y-%m-%d") == today_obj():
             diffdays += 1
         if diffdays <= 10:
             # caution: there may be today data!! then a day gap will be in table
-            self._updateurl = (
-                "http://fund.eastmoney.com/f10/F10DataApi.aspx?type=lsjz&code="
-                + self.code
-                + "&page=1&per="
-                + str(diffdays)
-            )
-            con = rget(self._updateurl)
-            soup = BeautifulSoup(con.text, "lxml")
-            items = soup.findAll("td")
+            self._updateurl = _lsjz_url(self.code, page=1, per=diffdays)
+            items = _lsjz_rows(self._updateurl)
         elif (
             diffdays > 10
         ):  ## there is a 20 item per page limit in the API, so to be safe, we query each page by 10 items only
             items = []
             for pg in range(1, int(diffdays / 10) + 2):
-                self._updateurl = (
-                    "http://fund.eastmoney.com/f10/F10DataApi.aspx?type=lsjz&code="
-                    + self.code
-                    + "&page="
-                    + str(pg)
-                    + "&per=10"
-                )
-                con = rget(self._updateurl)
-                soup = BeautifulSoup(con.text, "lxml")
-                items.extend(soup.findAll("td"))
+                self._updateurl = _lsjz_url(self.code, page=pg, per=10)
+                items.extend(_lsjz_rows(self._updateurl))
         else:
             raise TradeBehaviorError(
                 "Weird incremental update: the saved copy has future records"
@@ -1629,12 +1620,12 @@ class mfundinfo(basicinfo):
         date = []
         earnrate = []
         comment = []
-        for i in range(int(len(items) / 6)):
-            ts = pd.Timestamp(str(items[6 * i].string))
+        for item in items:
+            ts = pd.Timestamp(item["FSRQ"])
             if (ts - lastdate).days > 0:
                 date.append(ts)
-                earnrate.append(float(items[6 * i + 1].string) * 1e-4)
-                comment.append(_nfloat(items[6 * i + 5].string))
+                earnrate.append(float(item["DWJZ"]) * 1e-4)
+                comment.append(_nfloat(item["FHSP"]))
         date = date[::-1]
         earnrate = earnrate[::-1]
         comment = comment[::-1]


### PR DESCRIPTION
## 问题

天天基金已下线 `fund.eastmoney.com/f10/F10DataApi.aspx`。该地址目前 302 跳转到
`fundf10.eastmoney.com/F10DataApi.aspx`，而后者返回 404：

```
$ curl -sIL "http://fund.eastmoney.com/f10/F10DataApi.aspx?type=lsjz&code=110020&page=1&per=1"
302 -> https://fundf10.eastmoney.com/F10DataApi.aspx?...
404
```

该页面是 `fundinfo.update` 和 `mfundinfo.update` 的唯一数据来源，所以只要本地存在缓存副本，
场外基金的增量更新就会抛 `HttpStatusError`。表现比较隐蔽：首次抓取走 `pingzhongdata` 一切正常，
之后每一次更新都失败，因此只有配合 `set_backend` 长期使用的场景才会踩到。

## 改动

两处 `update` 改用 `api.fund.eastmoney.com/f10/lsjz`，JSON 字段与原表格列一一对应：

| 原表格列 | JSON 字段 |
| --- | --- |
| 净值日期 | `FSRQ` |
| 单位净值（货币基金为每万份收益） | `DWJZ` |
| 累计净值（货币基金为七日年化） | `LJJZ` |
| 分红送配 | `FHSP` |

分页逻辑保持不变 —— 新接口同样有每页 20 条的服务端上限（请求 `pageSize=60` 实际只返回 20 条），
原先每页 10 条的写法依然适用。请求需要带 `fundf10.eastmoney.com` 的 referer。

## 验证

`tests/test_info.py::test_fund_update`（覆盖 `fundinfo` 与 `mfundinfo` 两条增量路径）：

- 改动前：`FAILED ... xalpha.exceptions.HttpStatusError`
- 改动后：`1 passed`

`tests/test_info.py` 整体从 9 passed / 2 failed 变为 10 passed / 1 failed。仍失败的 `test_csvio`
是卡在 `indexinfo` 那一步（多次运行分别报 `SSLError` 和 `FileNotFoundError`），改动前后都存在，
与本 PR 无关。

另外单独核对过增量结果的正确性：把 `mfundinfo("000198")` 的净值表截去 6 行后调用 `update()`，
重建出的净值与完整抓取的表在 6 位小数上完全一致。